### PR TITLE
5.2 tweaks

### DIFF
--- a/admin/app/controllers/system/logs_controller.rb
+++ b/admin/app/controllers/system/logs_controller.rb
@@ -5,7 +5,6 @@ class System::LogsController < ApplicationController
       @logs = [
         {:path => '/var/log/maillog_webmin', :logdata => '', :accessible => false},
         {:path => '/var/log/clam-update.log', :logdata => '', :accessible => false},
-        {:path => '/var/log/nginx/error.log', :logdata => '', :accessible => false},
         {:path => '/var/log/messages_webmin.log', :logdata => '', :accessible => false},
         {:path => '/var/log/imap_webmin', :logdata => '', :accessiable => false},
         {:path => '/var/log/httpd.err', :logdata => '', :accessible => false},

--- a/install/install.sh
+++ b/install/install.sh
@@ -6,7 +6,7 @@ if [[ `uname -s` != "OpenBSD" ]]; then
 fi
 
 # git checkout branch for supported OpenBSD version or development branch
-if [ "`echo $1`" == "--devel" ]; then 
+if [ "`echo $1`" == "--devel" ]; then
   checkout_switch="devel"
   # detect changes in devel branch 
   branch_changes=`git --git-dir=/var/mailserv/.git --work-tree=/var/mailserv status -s`

--- a/install/scripts/10_pkg_add.sh
+++ b/install/scripts/10_pkg_add.sh
@@ -15,7 +15,7 @@ case $1 in
 You will be prompted to install:
  - postfix version. The recommendation is to install the first version 
  - php and php-mysql version. Use php-5.3.x and php-mysql-5.3.x
-
+ - p5-Mail-SPF and gnupg - accept default
 
 Fetching versions:
 
@@ -36,6 +36,7 @@ __EOT
      sqlgrey \
      nginx-- \
      god \
+     gsed \
      gtar--      
   
     pkg_add -v -m -i php \

--- a/install/scripts/20_install_etc.sh
+++ b/install/scripts/20_install_etc.sh
@@ -10,6 +10,11 @@ install /var/mailserv/install/templates/fs/sbin/* /usr/local/sbin/
 mkdir -p /usr/local/share/mailserv
 install /var/mailserv/install/templates/fs/mailserv/* /usr/local/share/mailserv
 
+# Create a 64M RAM disk to keep PHP sessions in
+mkdir -p /tmp/phpsessions
+mount_mfs -o rw,async,nodev,noexec,nosuid -s 131072 /dev/wd0b /tmp/phpsessions
+chown -R www:www /tmp/phpsessions
+echo "/dev/wd0b /tmp/phpsessions mfs rw,async,nodev,noexec,nosuid,-s=131072 0 0" >> /etc/fstab
 
 template="/var/mailserv/install/templates"
 install -m 644 \
@@ -97,6 +102,8 @@ if [[ $hi_ver_check == "true"  ]]; then
      echo "Updating rails:"
     /usr/local/bin/gem install -V -v=2.3.4 rails; 
 fi 
+
+gsed -i -E 's/(fastcgi_param +HTTPS)/#\1/' /etc/nginx/fastcgi_params
 
 # --------------------------------------------------------------
 # /etc/daily

--- a/install/scripts/32_php.sh
+++ b/install/scripts/32_php.sh
@@ -3,9 +3,12 @@
 # Only run on install
 if [[ "$1" == "install" ]]; then
 
-  # Install php.ini file
+  # Install php.ini file (this is a stock php.ini-production)
   /usr/bin/install -m 644 /var/mailserv/install/templates/php-5.3.ini /etc/
-  
+
+  # Install our local changes to php.ini
+  /usr/bin/install -m 644 /var/mailserv/install/templates/php-mailserv.ini /etc/php-5.3/mailserv.ini
+
   # Install php-fpm.conf (replace fast-cgi)
   /usr/bin/install -m 644 /var/mailserv/install/templates/php-fpm.conf /etc/ 
  
@@ -14,4 +17,7 @@ if [[ "$1" == "install" ]]; then
 
   # PHP APC config
   /usr/bin/install -m 644 /var/mailserv/install/templates/apc.ini /etc/php-5.3/
+
+  # Make php easier to run from CLI
+  ln -s /usr/local/bin/php-5.3 /usr/local/bin/php
 fi

--- a/install/templates/crontab_root
+++ b/install/templates/crontab_root
@@ -3,7 +3,7 @@
 # /var/cron/tabs/root - root's crontab
 #
 SHELL=/bin/sh
-PATH=/bin:/sbin:/usr/bin:/usr/sbin
+PATH=/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin
 HOME=/var/log
 #
 #minute	hour	mday	month	wday	command

--- a/install/templates/nginx.conf
+++ b/install/templates/nginx.conf
@@ -1,10 +1,10 @@
-user _nginx;
+user www;
 worker_processes  2;
 pid        /var/run/nginx.pid;
 error_log  /var/log/httpd.err error;
 
 events {
-    worker_connections  1024;
+    worker_connections  128;
 }
 
 http {
@@ -14,7 +14,7 @@ http {
 
   sendfile       on;
   tcp_nopush     on;
-  keepalive_timeout  65;
+  keepalive_timeout  5;
   server_name_in_redirect off;
 
   client_max_body_size 30M;
@@ -48,7 +48,7 @@ http {
     ssl on;
     root   /var/mailserv/admin/public;
 
-    location ~* \.(ico|css|js|gif|jp?g|png) {
+    location ~* \.(ico|css|js|gif|jpe?g|png) {
       access_log off;
       expires 7d;
       break;
@@ -79,14 +79,17 @@ http {
     ssl    on;
     root /var/www/webmail/webmail;
 
-    index  index.html index.htm index.php;
+    index  index.php index.html index.htm;
 
-    location ~ .php$ {
-      fastcgi_pass unix:/tmp/php.sock;
+    #See https://nealpoole.com/blog/2011/04/setting-up-php-fastcgi-and-nginx-dont-trust-the-tutorials-check-your-configuration/
+    location ~ \.php$ {
+      try_files $uri =404;
+      fastcgi_split_path_info ^(.+\.php)(/.+)$;
       fastcgi_index  index.php;
       include        fastcgi_params;
       fastcgi_param  HTTPS on;
       fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
+      fastcgi_pass unix:/var/run/php-fpm.sock;
     }
 
     location ^~ /account/stylesheets {
@@ -101,7 +104,7 @@ http {
       alias /var/mailserv/account/public/images;
     }
 
-    location ~* \.(ico|css|js|gif|jp?g|png) {
+    location ~* \.(ico|css|js|gif|jpe?g|png) {
       access_log off;
       expires 7d;
       break;
@@ -112,7 +115,7 @@ http {
       proxy_set_header  Host             $host;
       proxy_set_header  X-Real-IP        $remote_addr;
       proxy_set_header  X-Forwarded-For  $proxy_add_x_forwarded_for;
-      proxy_set_header	Port             $proxy_port;
+      proxy_set_header  Port             $proxy_port;
 
       if (!-f $request_filename.html) {
         proxy_pass  http://account_mongrels;

--- a/install/templates/php-5.3.ini
+++ b/install/templates/php-5.3.ini
@@ -19,7 +19,7 @@
 ; See the PHP docs for more specific information.
 ; http://php.net/configuration.file
 
-; The syntax of the file is extremely simple.  Whitespace and Lines
+; The syntax of the file is extremely simple.  Whitespace and lines
 ; beginning with a semicolon are silently ignored (as you probably guessed).
 ; Section headers (e.g. [Foo]) are also silently ignored, even though
 ; they might mean something in the future.
@@ -484,7 +484,7 @@ memory_limit = 128M
 ; development and early testing.
 ;
 ; Error Level Constants:
-; E_ALL             - All errors and warnings (includes E_STRICT as of PHP 6.0.0)
+; E_ALL             - All errors and warnings (includes E_STRICT as of PHP 5.4.0)
 ; E_ERROR           - fatal run-time errors
 ; E_RECOVERABLE_ERROR  - almost fatal run-time errors
 ; E_WARNING         - run-time warnings (non-fatal errors)
@@ -748,7 +748,7 @@ post_max_size = 8M
 ; enable the feature. We strongly recommend you use the escaping mechanisms
 ; designed specifically for the database your using instead of relying on this
 ; feature. Also note, this feature has been deprecated as of PHP 5.3.0 and is
-; scheduled for removal in PHP 6.
+; scheduled removed in PHP 5.4.
 ; Default Value: On
 ; Development Value: Off
 ; Production Value: Off
@@ -793,7 +793,10 @@ default_mimetype = "text/html"
 ;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; UNIX: "/path1:/path2"
-include_path = ".:/pear/lib:/var/www/pear/lib"
+;include_path = ".:/php/includes"
+;
+; Windows: "\path1;\path2"
+;include_path = ".;c:\php\includes"
 ;
 ; PHP's default setting for include_path is ".;/path/to/php/pear"
 ; http://php.net/include-path
@@ -816,7 +819,6 @@ user_dir =
 ; extension_dir = "./"
 ; On windows:
 ; extension_dir = "ext"
-extension_dir = "/usr/local/lib/php-5.3/modules"
 
 ; Whether or not to enable the dl() function.  The dl() function does NOT work
 ; properly in multithreaded servers, such as IIS or Zeus, and is automatically
@@ -897,7 +899,7 @@ max_file_uploads = 20
 
 ; Whether to allow the treatment of URLs (like http:// or ftp://) as files.
 ; http://php.net/allow-url-fopen
-allow_url_fopen = Off
+allow_url_fopen = On
 
 ; Whether to allow include/require to open URLs (like http:// or ftp://) as files.
 ; http://php.net/allow-url-include
@@ -1003,7 +1005,7 @@ default_socket_timeout = 60
 [Date]
 ; Defines the default timezone used by the date functions
 ; http://php.net/date.timezone
-date.timezone = "Europe/London"
+;date.timezone =
 
 ; http://php.net/date.default-latitude
 ;date.default_latitude = 31.7667
@@ -1495,7 +1497,7 @@ session.use_cookies = 1
 ;session.cookie_secure =
 
 ; This option forces PHP to fetch and use a cookie for storing and maintaining
-; the session id. We encourage this operation as it's very helpful in combatting
+; the session id. We encourage this operation as it's very helpful in combating
 ; session hijacking when not specifying and managing your own session id. It is
 ; not the end all be all of session hijacking defense, but it's a good start.
 ; http://php.net/session.use-only-cookies
@@ -1625,7 +1627,7 @@ session.cache_expire = 180
 ; - User may send URL contains active session ID
 ;   to other person via. email/irc/etc.
 ; - URL that contains active session ID may be stored
-;   in publically accessible computer.
+;   in publicly accessible computer.
 ; - User may access your site with the same session ID
 ;   always using URL stored in browser's history or bookmarks.
 ; http://php.net/session.use-trans-sid
@@ -1904,446 +1906,6 @@ ldap.max_links = -1
 
 [dba]
 ;dba.default_handler=
-
-[suhosin]
-
-; -----------------------------------------------------------------------------
-; Logging Options
-
-; Defines what classes of security alerts are logged to the syslog daemon.
-; Logging of errors of the class S_MEMORY are always logged to syslog, no
-; matter what this configuration says, because a corrupted heap could mean that
-; the other logging options will malfunction during the logging process.
-;suhosin.log.syslog = 
-
-; Defines the syslog facility that is used when ALERTs are logged to syslog.
-;suhosin.log.syslog.facility = 
-
-; Defines the syslog priority that is used when ALERTs are logged to syslog.
-;suhosin.log.syslog.priority = 
-
-; Defines what classes of security alerts are logged through the SAPI error log.
-;suhosin.log.sapi = 
-
-; Defines what classes of security alerts are logged through the external
-; logging.
-;suhosin.log.script = 
-
-; Defines what classes of security alerts are logged through the defined PHP
-; script.
-;suhosin.log.phpscript = 0
-
-; Defines the full path to a external logging script. The script is called with
-; 2 parameters. The first one is the alert class in string notation and the
-; second parameter is the log message. This can be used for example to mail
-; failing MySQL queries to your email address, because on a production system
-; these things should never happen.
-;suhosin.log.script.name = 
-
-; Defines the full path to a PHP logging script. The script is called with 2
-; variables registered in the current scope: SUHOSIN_ERRORCLASS and
-; SUHOSIN_ERROR. The first one is the alert class and the second variable is
-; the log message. This can be used for example to mail attempted remote URL
-; include attacks to your email address.
-;suhosin.log.phpscript.name = 
-
-; Undocumented
-;suhosin.log.phpscript.is_safe = Off
-
-; When the Hardening-Patch logs an error the log message also contains the IP
-; of the attacker. Usually this IP is retrieved from the REMOTE_ADDR SAPI
-; environment variable. With this switch it is possible to change this behavior
-; to read the IP from the X-Forwarded-For HTTP header. This is f.e. necessary
-; when your PHP server runs behind a reverse proxy.
-;suhosin.log.use-x-forwarded-for = Off
-
-; -----------------------------------------------------------------------------
-; Executor Options
-
-; Defines the maximum stack depth allowed by the executor before it stops the
-; script. Without this function an endless recursion in a PHP script could
-; crash the PHP executor or trigger the configured memory_limit. A value of
-; "0" disables this feature.
-;suhosin.executor.max_depth = 0
-
-; Defines how many "../" an include filename needs to contain to be considered
-; an attack and stopped. A value of "2" will block "../../etc/passwd", while a
-; value of "3" will allow it. Most PHP applications should work flawlessly with
-; values "4" or "5". A value of "0" disables this feature.
-;suhosin.executor.include.max_traversal = 0
-
-; Comma separated whitelist of URL schemes that are allowed to be included from
-; include or require statements. Additionally to URL schemes it is possible to
-; specify the beginning of allowed URLs. (f.e.: php://stdin) If no whitelist is
-; specified, then the blacklist is evaluated.
-;suhosin.executor.include.whitelist = 
-
-; Comma separated blacklist of URL schemes that are not allowed to be included
-; from include or require statements. Additionally to URL schemes it is
-; possible to specify the beginning of allowed URLs. (f.e.: php://stdin) If no
-; blacklist and no whitelist is specified all URL schemes are forbidden.
-;suhosin.executor.include.blacklist = 
-
-; Defines if PHP is allows to run code from files that are writable by the
-; current process. If a file is created or modified by a PHP process, there
-; is a potential danger of code injection. Only turn this on if you are sure
-; that your application does not require writable PHP files.
-;suhosin.executor.include.allow_writable_files = On
-
-; Comma separated whitelist of functions that are allowed to be called. If the
-; whitelist is empty the blacklist is evaluated, otherwise calling a function
-; not in the whitelist will terminate the script and get logged.
-;suhosin.executor.func.whitelist = 
-
-; Comma separated blacklist of functions that are not allowed to be called. If
-; no whitelist is given, calling a function within the blacklist will terminate
-; the script and get logged. 
-;suhosin.executor.func.blacklist = 
-
-; Comma separated whitelist of functions that are allowed to be called from
-; within eval(). If the whitelist is empty the blacklist is evaluated,
-; otherwise calling a function not in the whitelist will terminate the script
-; and get logged.
-;suhosin.executor.eval.whitelist = 
-
-; Comma separated blacklist of functions that are not allowed to be called from
-; within eval(). If no whitelist is given, calling a function within the
-; blacklist will terminate the script and get logged.
-;suhosin.executor.eval.blacklist = 
-
-; eval() is a very dangerous statement and therefore you might want to disable
-; it completely. Deactivating it will however break lots of scripts. Because
-; every violation is logged, this allows finding all places where eval() is
-; used.
-;suhosin.executor.disable_eval = Off
-
-; The /e modifier inside preg_replace() allows code execution. Often it is the
-; cause for remote code execution exploits. It is wise to deactivate this
-; feature and test where in the application it is used. The developer using the
-; /e modifier should be made aware that he should use preg_replace_callback()
-; instead.
-;suhosin.executor.disable_emodifier = Off
-
-; This flag reactivates symlink() when open_basedir is used, which is disabled
-; by default in Suhosin >= 0.9.6. Allowing symlink() while open_basedir is used
-; is actually a security risk. 
-;suhosin.executor.allow_symlink = Off
-
-; -----------------------------------------------------------------------------
-; Misc Options
-
-; If you fear that Suhosin breaks your application, you can activate Suhosin's
-; simulation mode with this flag. When Suhosin runs in simulation mode,
-; violations are logged as usual, but nothing is blocked or removed from the
-; request. (Transparent features are NOT deactivated in simulation mode.)
-; (since v0.9.30 affects (dis)allowed functions)
-;suhosin.simulation = Off
-
-; APC 3.0.12(p1/p2) uses reserved resources without requesting a resource slot
-; first. It always uses resource slot 0. If Suhosin got this slot assigned APC
-; will overwrite the information Suhosin stores in this slot. When this flag is
-; set Suhosin will request 2 Slots and use the second one. This allows working
-; correctly with these buggy APC versions.
-;suhosin.apc_bug_workaround = Off
-
-; When a SQL Query fails scripts often spit out a bunch of useful information
-; for possible attackers. When this configuration directive is turned on, the
-; script will silently terminate, after the problem has been logged. (This is
-; not yet supported)
-;suhosin.sql.bailout_on_error = Off
-
-; This is an experimental feature for shared environments. With this
-; configuration option it is possible to specify a prefix that is automatically
-; prepended to the database username, whenever a database connection is made.
-; (Unless the username starts with the prefix)
-;suhosin.sql.user_prefix = 
-
-; This is an experimental feature for shared environments. With this
-; configuration option it is possible to specify a postfix that is
-; automatically appended to the database username, whenever a database
-; connection is made. (Unless the username end with the postfix)
-;
-; With this feature it is possible for shared hosters to disallow customers to
-; connect with the usernames of other customers. This feature is experimental,
-; because support for PDO and PostgreSQL are not yet implemented. 
-;suhosin.sql.user_postfix = 
-
-; This directive controls if multiple headers are allowed or not in a header()
-; call. By default the Hardening-Patch forbids this. (HTTP headers spanning
-; multiple lines are still allowed).
-;suhosin.multiheader = Off
-
-; This directive controls if the mail() header protection is activated or not
-; and to what degree it is activated. The appended table lists the possible
-; activation levels.
-suhosin.mail.protect = 1
-
-; As long scripts are not running within safe_mode they are free to change the
-; memory_limit to whatever value they want. Suhosin changes this fact and
-; disallows setting the memory_limit to a value greater than the one the script
-; started with, when this option is left at 0. A value greater than 0 means
-; that Suhosin will disallows scripts setting the memory_limit to a value above
-; this configured hard limit. This is for example usefull if you want to run
-; the script normaly with a limit of 16M but image processing scripts may raise
-; it to 20M.
-;suhosin.memory_limit = 0
-
-; -----------------------------------------------------------------------------
-; Transparent Encryption Options
-
-; Flag that decides if the transparent session encryption is activated or not.
-suhosin.session.encrypt = Off 
-
-; Session data can be encrypted transparently. The encryption key used consists
-; of this user defined string (which can be altered by a script via ini_set())
-; and optionally the User-Agent, the Document-Root and 0-4 Octects of the
-; REMOTE_ADDR.
-;suhosin.session.cryptkey = 
-
-; Flag that decides if the transparent session encryption key depends on the
-; User-Agent field. (When activated this feature transparently adds a little
-; bit protection against session fixation/hijacking attacks)
-;suhosin.session.cryptua = On
-
-; Flag that decides if the transparent session encryption key depends on the
-; Documentroot field.
-;suhosin.session.cryptdocroot = On
-
-; Number of octets (0-4) from the REMOTE_ADDR that the transparent session
-; encryption key depends on. Keep in mind that this should not be used on sites
-; that have visitors from big ISPs, because their IP address often changes
-; during a session. But this feature might be interesting for admin interfaces
-; or intranets. When used wisely this is a transparent protection against
-; session hijacking/fixation. 
-;suhosin.session.cryptraddr = 0
-
-; Number of octets (0-4) from the REMOTE_ADDR that have to match to decrypt the
-; session. The difference to suhosin.session.cryptaddr is, that the IP is not
-; part of the encryption key, so that the same session can be used for
-; different areas with different protection levels on the site.
-;suhosin.session.checkraddr = 0
-
-; Flag that decides if the transparent cookie encryption is activated or not.
-;suhosin.cookie.encrypt = 0
-
-; Cookies can be encrypted transparently. The encryption key used consists of
-; this user defined string and optionally the User-Agent, the Document-Root and
-; 0-4 Octects of the REMOTE_ADDR.
-;suhosin.cookie.cryptkey = 
-
-; Flag that decides if the transparent session encryption key depends on the
-; User-Agent field. (When activated this feature transparently adds a little
-; bit protection against session fixation/hijacking attacks (if only session
-; cookies are allowed))
-;suhosin.cookie.cryptua = On
-
-; Flag that decides if the transparent cookie encryption key depends on the
-; Documentroot field.
-;suhosin.cookie.cryptdocroot = On
-
-; Number of octets (0-4) from the REMOTE_ADDR that the transparent cookie
-; encryption key depends on. Keep in mind that this should not be used on sites
-; that have visitors from big ISPs, because their IP address often changes
-; during a session. But this feature might be interesting for admin interfaces
-; or intranets. When used wisely this is a transparent protection against
-; session hijacking/fixation.
-;suhosin.cookie.cryptraddr = 0
-
-; Number of octets (0-4) from the REMOTE_ADDR that have to match to decrypt the
-; cookie. The difference to suhosin.cookie.cryptaddr is, that the IP is not
-; part of the encryption key, so that the same cookie can be used for different
-; areas with different protection levels on the site.
-;suhosin.cookie.checkraddr = 0
-
-; In case not all cookies are supposed to get encrypted this is a comma
-; separated list of cookie names that should get encrypted. All other cookies
-; will not get touched.
-;suhosin.cookie.cryptlist = 
-
-; In case some cookies should not be crypted this is a comma separated list of
-; cookies that do not get encrypted. All other cookies will be encrypted.
-;suhosin.cookie.plainlist = 
-
-; -----------------------------------------------------------------------------
-; Filtering Options
-
-; Defines the reaction of Suhosin on a filter violation.
-;suhosin.filter.action = 
-
-; Defines the maximum depth an array variable may have, when registered through
-; the COOKIE.
-;suhosin.cookie.max_array_depth = 50
-
-; Defines the maximum length of array indices for variables registered through
-; the COOKIE.
-;suhosin.cookie.max_array_index_length = 64
-
-; Defines the maximum length of variable names for variables registered through
-; the COOKIE. For array variables this is the name in front of the indices.
-;suhosin.cookie.max_name_length = 64
-
-; Defines the maximum length of the total variable name when registered through
-; the COOKIE. For array variables this includes all indices.
-;suhosin.cookie.max_totalname_length = 256
-
-; Defines the maximum length of a variable that is registered through the
-; COOKIE.
-;suhosin.cookie.max_value_length = 10000
-
-; Defines the maximum number of variables that may be registered through the
-; COOKIE.
-;suhosin.cookie.max_vars = 100
-
-; When set to On ASCIIZ chars are not allowed in variables.
-;suhosin.cookie.disallow_nul = 1
-
-; Defines the maximum depth an array variable may have, when registered through
-; the URL
-;suhosin.get.max_array_depth = 50
-
-; Defines the maximum length of array indices for variables registered through
-; the URL
-;suhosin.get.max_array_index_length = 64
-
-; Defines the maximum length of variable names for variables registered through
-; the URL. For array variables this is the name in front of the indices.
-;suhosin.get.max_name_length = 64
-
-; Defines the maximum length of the total variable name when registered through
-; the URL. For array variables this includes all indices.
-;suhosin.get.max_totalname_length = 256
-
-; Defines the maximum length of a variable that is registered through the URL.
-;suhosin.get.max_value_length = 512
-
-; Defines the maximum number of variables that may be registered through the
-; URL.
-;suhosin.get.max_vars = 100
-
-; When set to On ASCIIZ chars are not allowed in variables.
-;suhosin.get.disallow_nul = 1
-
-; Defines the maximum depth an array variable may have, when registered through
-; a POST request.
-;suhosin.post.max_array_depth = 50
-
-; Defines the maximum length of array indices for variables registered through
-; a POST request.
-;suhosin.post.max_array_index_length = 64
-
-; Defines the maximum length of variable names for variables registered through
-; a POST request. For array variables this is the name in front of the indices.
-;suhosin.post.max_name_length = 64
-
-; Defines the maximum length of the total variable name when registered through
-; a POST request. For array variables this includes all indices.
-;suhosin.post.max_totalname_length = 256
-
-; Defines the maximum length of a variable that is registered through a POST
-; request.
-;suhosin.post.max_value_length = 1000000
-
-; Defines the maximum number of variables that may be registered through a POST
-; request.
-;suhosin.post.max_vars = 1000
-
-; When set to On ASCIIZ chars are not allowed in variables.
-;suhosin.post.disallow_nul = 1
-
-; Defines the maximum depth an array variable may have, when registered through
-; GET , POST or COOKIE. This setting is also an upper limit for the separate
-; GET, POST, COOKIE configuration directives.
-;suhosin.request.max_array_depth = 50
-
-; Defines the maximum length of array indices for variables registered through
-; GET, POST or COOKIE. This setting is also an upper limit for the separate
-; GET, POST, COOKIE configuration directives.
-;suhosin.request.max_array_index_length = 64
-
-; Defines the maximum length of variable names for variables registered through
-; the COOKIE, the URL or through a POST request. This is the complete name
-; string, including all indicies. This setting is also an upper limit for the
-; separate GET, POST, COOKIE configuration directives.
-;suhosin.request.max_totalname_length = 256
-
-; Defines the maximum length of a variable that is registered through the
-; COOKIE, the URL or through a POST request. This setting is also an upper
-; limit for the variable origin specific configuration directives.
-;suhosin.request.max_value_length = 1000000
-
-; Defines the maximum number of variables that may be registered through the
-; COOKIE, the URL or through a POST request. This setting is also an upper
-; limit for the variable origin specific configuration directives.
-;suhosin.request.max_vars = 1000
-
-; Defines the maximum name length (excluding possible array indicies) of
-; variables that may be registered through the COOKIE, the URL or through a
-; POST request. This setting is also an upper limit for the variable origin
-; specific configuration directives.
-;suhosin.request.max_varname_length = 64
-
-; When set to On ASCIIZ chars are not allowed in variables.
-;suhosin.request.disallow_nul = 1
-
-; When set to On the dangerous characters <>"'` are urlencoded when found
-; not encoded in the server variables REQUEST_URI and QUERY_STRING. This
-; will protect against some XSS vulnerabilities.
-;suhosin.server.encode = 1
-
-; When set to On the dangerous characters <>"'` are replaced with ? in
-; the server variables PHP_SELF, PATH_TRANSLATED and PATH_INFO. This will
-; protect against some XSS vulnerabilities.
-;suhosin.server.strip = 1
-
-; Defines the maximum number of files that may be uploaded with one request.
-;suhosin.upload.max_uploads = 25
-
-; When set to On it is not possible to upload ELF executables.
-;suhosin.upload.disallow_elf = 1
-
-; When set to On it is not possible to upload binary files.
-;suhosin.upload.disallow_binary = 0
-
-; When set to On binary content is removed from the uploaded files.
-;suhosin.upload.remove_binary = 0
-
-; This defines the full path to a verification script for uploaded files. The
-; script gets the temporary filename supplied and has to decide if the upload
-; is allowed. A possible application for this is to scan uploaded files for
-; viruses. The called script has to write a 1 as first line to standard output
-; to allow the upload. Any other value or no output at all will result in the
-; file being deleted.
-;suhosin.upload.verification_script = 
-
-; Specifies the maximum length of the session identifier that is allowed. When
-; a longer session identifier is passed a new session identifier will be
-; created. This feature is important to fight bufferoverflows in 3rd party
-; session handlers.
-;suhosin.session.max_id_length = 128
-
-; Undocumented: Controls if suhosin coredumps when the optional suhosin patch 
-; detects a bufferoverflow, memory corruption or double free. This is only
-; for debugging purposes and should not be activated.
-;suhosin.coredump = Off
-
-; Undocumented: Controls if the encryption keys specified by the configuration
-; are shown in the phpinfo() output or if they are hidden from it
-;suhosin.protectkey = 1
-
-; Controls if suhosin loads in stealth mode when it is not the only
-; zend_extension (Required for full compatibility with certain encoders 
-;  that consider open source untrusted. e.g. ionCube, Zend)
-;suhosin.stealth = 1
-
-; Controls if suhosin's ini directives are changeable per directory
-; because the admin might want to allow some features to be controlable
-; by .htaccess and some not. For example the logging capabilities can
-; break safemode and open_basedir restrictions when .htaccess support is
-; allowed and the admin forgot to fix their values in httpd.conf
-; An empty value or a 0 will result in all directives not allowed in
-; .htaccess. The string "legcprsum" will allow logging, execution, get, 
-; post, cookie, request, sql, upload, misc features in .htaccess
-;suhosin.perdir = "0"
 
 [xsl]
 ; Write operations from within XSLT are disabled by default.

--- a/install/templates/php-fpm.conf
+++ b/install/templates/php-fpm.conf
@@ -130,8 +130,8 @@ prefix = /var/www/
 ; Unix user/group of processes
 ; Note: The user is mandatory. If the group is not set, the default user's group
 ;       will be used.
-user = _nginx 
-group = _nginx  
+user = www
+group = www
 
 ; The address on which to accept FastCGI requests.
 ; Valid syntaxes are:
@@ -142,7 +142,7 @@ group = _nginx
 ;   '/path/to/unix/socket' - to listen on a unix socket.
 ; Note: This value is mandatory.
 ;;listen = 127.0.0.1:9000
-listen = /tmp/php.sock
+listen = /var/run/php-fpm.sock
 
 ; Set listen(2) backlog. A value of '-1' means unlimited.
 ; Default Value: 128 (-1 on FreeBSD and OpenBSD)

--- a/install/templates/php-mailserv.ini
+++ b/install/templates/php-mailserv.ini
@@ -1,0 +1,25 @@
+[PHP]
+expose_php = Off
+max_execution_time = 120
+max_input_time = 120
+default_socket_timeout = 120
+post_max_size = 16M
+upload_max_filesize = 16M
+extension_dir = "/usr/local/lib/php-5.3/modules"
+allow_url_fopen = Off
+
+[Session]
+session.save_path = /tmp/phpsessions
+
+[suhosin]
+suhosin.session.encrypt = Off
+
+[Date]
+date.timezone = "Etc/UTC"
+
+[mysql]
+mysql.default_socket = /var/run/mysql/mysql.sock
+
+[mysqli]
+mysqli.default_socket = /var/run/mysql/mysql.sock
+mysqli.reconnect = On


### PR DESCRIPTION
Tested by a couple of people on the mailing list. All working, but something is still installing nginx 1.2.2 in /usr/sbin/nginx.

Make devel install verbose for easier debugging
Use a stock php.ini-production and separate out our changes
Fix nginx user
set -xv doesn't do anything :(
Remove non-existent log file from admin UI
Reduce worker_connections to fit into OpenBSD limits
Reduce keepalive to recycle connections faster
Note about alternative packages that the installer asks about
Store PHP sessions in a ramdisk
Fix RoundCube suhosin settings
Fix insecure nginx PHP config
Add and use gsed to fix nginx fastcgi params
Fix sed regex
